### PR TITLE
feat: 1.2.4 - Bump koliseo to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,5 +147,5 @@
 
   - `darwin-arm64`
 
-  📦 v1.2.3 06/10/2023
+  📦 v1.2.4 12/10/2023
   https://github.com/jgabaut/helapordo/releases

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -35,4 +35,4 @@ kazoj# tests folder name
 1.2.1# Enemies can pick FOE_FIGHT without -X
 1.2.2# Bosses can pick FOE_FIGHT, fix crash on retry()
 1.2.3# Fix -r -E flags, check ncurses version, bump s4c to 0.3.4, amboso to 1.6.6
-1.2.4# Bump koliseo to 0.2.4
+1.2.4# Bump koliseo to 0.3.0, drop DEMO{FRAMES,ROWS,COLS,FRAMETIME}

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -35,3 +35,4 @@ kazoj# tests folder name
 1.2.1# Enemies can pick FOE_FIGHT without -X
 1.2.2# Bosses can pick FOE_FIGHT, fix crash on retry()
 1.2.3# Fix -r -E flags, check ncurses version, bump s4c to 0.3.4, amboso to 1.6.6
+1.2.4# Bump koliseo to 0.2.4

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Define the package name and version
-AC_INIT([helapordo], [1.2.3], [jgabaut@github.com])
+AC_INIT([helapordo], [1.2.4], [jgabaut@github.com])
 
 # Verify automake version and enable foreign option
 AM_INIT_AUTOMAKE([foreign -Wall])
@@ -48,7 +48,7 @@ fi
 # Set a default version number if not specified externally
 AC_ARG_VAR([VERSION], [Version number])
 if test -z "$VERSION"; then
-  VERSION="1.2.3"
+  VERSION="1.2.4"
 fi
 
 # Output variables to the config.h header

--- a/docs/helapordo.doxyfile
+++ b/docs/helapordo.doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "helapordo"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "1.2.3"
+PROJECT_NUMBER         = "1.2.4"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/game_core.h
+++ b/src/game_core.h
@@ -1850,4 +1850,9 @@ extern char* fightresultstrings[FIGHT_RES_TOT+1];
  */
 OP_res OP_res_from_fightResult(fightResult fr);
 
+#define CHEST_FRAMES 25 /**< Defines the number of frames for the chest animation.*/
+#define CHEST_ROWS 18 /**< Defines the number of rows for the chest animation.*/
+#define CHEST_COLS 18 /**< Defines the number of cols for the chest animation.*/
+#define CHEST_FRAMETIME 67 /**< Defines for how many millisecs a sprite should stay on screen for the chest animation.*/
+
 #endif

--- a/src/game_core.h
+++ b/src/game_core.h
@@ -142,12 +142,12 @@ extern int G_DOTUTORIAL_ON;
 /**
  * Current patch release.
  */
-#define HELAPORDO_PATCH_VERSION 3
+#define HELAPORDO_PATCH_VERSION 4
 
 /**
  * Current version string identifier, with MAJOR.MINOR.PATCH format.
  */
-#define VERSION "1.2.3"
+#define VERSION "1.2.4"
 
 /**
  * Default savepath.

--- a/src/helapordo.c
+++ b/src/helapordo.c
@@ -10366,11 +10366,12 @@ Path* randomise_path(int seed, Koliseo* kls, const char* path_to_savefile){
 void gameloop(int argc, char** argv){
 
   char* whoami; // This will reference argv[0] at basename, it's the same string in memory, just starting later
+  KLS_Conf kls_conf = { .kls_autoset_regions = 1, .kls_autoset_temp_regions = 0};
 
 	do {
 		//Init default_kls
-		default_kls = kls_new(KLS_DEFAULT_SIZE*16);
-		temporary_kls = kls_new(KLS_DEFAULT_SIZE*32);
+		default_kls = kls_new_conf(KLS_DEFAULT_SIZE*16, kls_conf);
+		temporary_kls = kls_new_conf(KLS_DEFAULT_SIZE*32, kls_conf);
 
 		#ifndef _WIN32
 		(whoami = strrchr(argv[0], '/')) ? ++whoami : (whoami = argv[0]);
@@ -10378,7 +10379,7 @@ void gameloop(int argc, char** argv){
 		(whoami = strrchr(argv[0], '\\')) ? ++whoami : (whoami = argv[0]);
 		#endif
 
-		char* kls_progname = (char*) KLS_PUSH_TYPED(default_kls, char*, sizeof(whoami),None,"progname",whoami);
+		char* kls_progname = (char*) KLS_PUSH_TYPED(default_kls, char*, sizeof(whoami),KLS_None,"progname",whoami);
 		strcpy(kls_progname,whoami);
 
 		#ifndef HELAPORDO_DEBUG_LOG
@@ -12058,10 +12059,11 @@ void gameloop(int argc, char** argv){
  */
 void gameloop_Win(int argc, char** argv) {
 	char* whoami;
+    KLS_Conf kls_conf = { .kls_autoset_regions = 1, .kls_autoset_temp_regions = 0};
 	(whoami = strrchr(argv[0], '\\')) ? ++whoami : (whoami = argv[0]);
 	do {
-		default_kls = kls_new(KLS_DEFAULT_SIZE*8);
-		temporary_kls = kls_new(KLS_DEFAULT_SIZE*8);
+		default_kls = kls_new_conf(KLS_DEFAULT_SIZE*8, kls_conf);
+		temporary_kls = kls_new_conf(KLS_DEFAULT_SIZE*8, kls_conf);
 		char* kls_progname = (char*) KLS_PUSH_TYPED(default_kls, char*, sizeof(whoami),None,"progname",whoami);
 		strcpy(kls_progname,whoami);
 		#ifndef HELAPORDO_DEBUG_LOG

--- a/src/helapordo.h
+++ b/src/helapordo.h
@@ -20,10 +20,6 @@
 
 #include <locale.h>
 #include <sys/stat.h>
-#define DEMOFRAMES 25 /**< Defines the number of sprites in the demo.*/
-#define DEMOROWS 18 /**< Defines the maximum number of rows per sprite.*/
-#define DEMOCOLS 18 /**< Defines the maximum number of colums per sprite.*/
-#define DEMOFRAMETIME 67 /**< Defines for how many millisecs a sprite should stay on screen in the demo.*/
 #include "game_core.h"
 #include "game_utils.h"
 #include "rooms.h"

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@ Koliseo* temporary_kls = NULL;
 
 int main(int argc, char** argv) {
 	KOLISEO_AUTOSET_TEMP_REGIONS = 0; //Disable regions for Koliseo_Temp allocations
+	KOLISEO_AUTOSET_REGIONS = 1; //Enable regions for Koliseo_Temp allocations
 	//Randomise seed
 	srand(time(NULL));
 

--- a/src/main.c
+++ b/src/main.c
@@ -23,8 +23,6 @@ Koliseo* temporary_kls = NULL;
 
 
 int main(int argc, char** argv) {
-	KOLISEO_AUTOSET_TEMP_REGIONS = 0; //Disable regions for Koliseo_Temp allocations
-	KOLISEO_AUTOSET_REGIONS = 1; //Enable regions for Koliseo_Temp allocations
 	//Randomise seed
 	srand(time(NULL));
 

--- a/src/rooms.c
+++ b/src/rooms.c
@@ -2247,13 +2247,13 @@ void open_chest(WINDOW* w, Chest * c, Fighter* f, Koliseo* kls,  Koliseo_Temp* t
 
 	int reps = 1;
 
-	int frametime = DEMOFRAMETIME;
+	int frametime = CHEST_FRAMETIME;
 
-	int num_frames = DEMOFRAMES;
+	int num_frames = CHEST_FRAMES;
 
-	int frame_height = DEMOROWS;
+	int frame_height = CHEST_ROWS;
 
-	int frame_width = DEMOCOLS;
+	int frame_width = CHEST_COLS;
 
 	// Prepare the frames
 	char sprites[MAXFRAMES][MAXROWS][MAXCOLS];


### PR DESCRIPTION
- Bumps `koliseo` to `0.3.0`.
  - Changes `kls_new()` calls to `kls_new_conf()`.
- Moves some defines used in `rooms.c` from `helapordo.h` to `game_core.h`.